### PR TITLE
Close <a> tag in error view template

### DIFF
--- a/src/core/views/404.tpl
+++ b/src/core/views/404.tpl
@@ -67,7 +67,7 @@ a.underline, .underline{
 		        <span class="status-text">Page Not Found</span>
 		    </div>
 		    <div class="status-subtitle">
-		        <p> <a href="/harbor" class="underline">Home</p>
+		        <p><a href="/harbor" class="underline">Home</a></p>
 		    </div>
         </div>
     </div>


### PR DESCRIPTION
The error view template was missing a closing <a> tag in the link to the harbor portal.

Signed-off-by: Pedro Laguna <plaguna@vmware.com>